### PR TITLE
Updated swift-tools-version to remove generate-xcodeproj warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:4.2
 
 import PackageDescription
 


### PR DESCRIPTION
"swift package generate-xcodeproj" produces a warning because of the swift-tools-version setting.
(Xcode 10)